### PR TITLE
Get params from the xacro in the driver's repo

### DIFF
--- a/kuka_iisy_support/launch/rviz_iisy.launch.py
+++ b/kuka_iisy_support/launch/rviz_iisy.launch.py
@@ -44,7 +44,7 @@ def load_yaml(package_name, file_path):
 def generate_launch_description():
 
     robot_description_config = load_file(
-        'kuka_iisy_support', 'urdf/iisy.urdf')
+        'kuka_iisy_support', 'urdf/iisy.urdf.xacro')
     robot_description = {'robot_description': robot_description_config}
 
     # RViz

--- a/kuka_iisy_support/launch/rviz_iisy.launch.py
+++ b/kuka_iisy_support/launch/rviz_iisy.launch.py
@@ -44,12 +44,12 @@ def load_yaml(package_name, file_path):
 def generate_launch_description():
 
     robot_description_config = load_file(
-        'kuka_iisy_support', 'urdf/iisy.urdf.xacro')
+        'kuka_rox_hw_interface', 'config/iisy.urdf.xacro')
     robot_description = {'robot_description': robot_description_config}
 
     # RViz
     rviz_config_file = get_package_share_directory(
-        'kuka_iisy_support') + "/launch/urdf.rviz"
+        'kuka_rox_hw_interface') + "/launch/urdf.rviz"
     rviz_node = Node(package='rviz2',
                      executable='rviz2',
                      name='rviz2_launch',

--- a/kuka_iisy_support/launch/rviz_simtime.launch.py
+++ b/kuka_iisy_support/launch/rviz_simtime.launch.py
@@ -40,7 +40,7 @@ def load_yaml(package_name, file_path):
 
 
 def generate_launch_description():
-    robot_description_config = load_file('iisy_support', 'urdf/iisy.urdf')
+    robot_description_config = load_file('iisy_support', 'urdf/iisy.urdf.xacro')
     robot_description = {'robot_description' : robot_description_config}
     sim_time_true = {'use_sim_time' : True}
 

--- a/kuka_iisy_support/urdf/iisy.ros2_control.urdf.xacro
+++ b/kuka_iisy_support/urdf/iisy.ros2_control.urdf.xacro
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<robot name="LBR3R760iisy">
+<robot name="LBR3R760iisy" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:macro name="eci_config" params="client_ip controller_ip control_mode">
   <ros2_control name="iisy_hardware" type="system">
     <hardware>
       <plugin>kuka_rox::KukaRoXHardwareInterface</plugin>
+      <param name="client_ip">${client_ip}</param>
+      <param name="controller_ip">${controller_ip}</param>
+      <param name="control_mode">${control_mode}</param>
     </hardware>
     <!-- define joints and command/state interfaces for each joint -->
     <joint name="joint_a1">
@@ -300,4 +304,5 @@
     </joint>
     <type>transmission_interface/SimpleTransmission</type>
   </transmission>
+  </xacro:macro>
 </robot>

--- a/kuka_iisy_support/urdf/iisy.urdf.xacro
+++ b/kuka_iisy_support/urdf/iisy.urdf.xacro
@@ -1,9 +1,0 @@
-<?xml version="1.0"?>
-<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="LBR3R760iisy">
-<!-- Import iisy urdf file  -->
-<xacro:include filename="$(find kuka_iisy_support)/urdf/iisy.ros2_control.urdf.xacro"/>
-
-<xacro:eci_config client_ip="10.36.60.228" 
-                  controller_ip="10.36.60.227" 
-                  control_mode="position_control"/>
-</robot>

--- a/kuka_iisy_support/urdf/iisy.urdf.xacro
+++ b/kuka_iisy_support/urdf/iisy.urdf.xacro
@@ -1,5 +1,9 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="LBR3R760iisy">
-    <!-- Import iisy urdf file -->
-    <xacro:include filename="iisy.urdf" />
+<!-- Import iisy urdf file  -->
+<xacro:include filename="$(find kuka_iisy_support)/urdf/iisy.ros2_control.urdf.xacro"/>
+
+<xacro:eci_config client_ip="10.36.60.228" 
+                  controller_ip="10.36.60.227" 
+                  control_mode="position_control"/>
 </robot>


### PR DESCRIPTION
This PR creates a macro from the urdf file, which can be instantiated in the external configuration's xacro file.

This workaround makes it possible to change the client / controller IP and control mode without recompiling the code every time these parameters are changed.
