### PR TITLE
Add mock hardware option to LBR iisy 3 R760 ros2_control file

### DIFF
--- a/kuka_lbr_iisy_support/urdf/lbr_iisy3_r760.urdf.xacro
+++ b/kuka_lbr_iisy_support/urdf/lbr_iisy3_r760.urdf.xacro
@@ -17,6 +17,8 @@
 <xacro:property name="lost_packets_in_timeframe" value="${qos_config_dict['rt_packet_loss_profile']['lost_packets_in_timeframe']}" />
 <xacro:property name="timeframe_ms" value="${qos_config_dict['rt_packet_loss_profile']['timeframe_ms']}" />
 
+<!-- Read additional arguments  -->
+<xacro:arg name="use_fake_hardware" default="false" />
 
 <xacro:kuka_lbr3_r760_robot prefix=""
                   client_ip="${client_ip}" 
@@ -24,5 +26,6 @@
                   control_mode="${control_mode}"
                   consequent_lost_packets="${consequent_lost_packets}" 
                   lost_packets_in_timeframe="${lost_packets_in_timeframe}" 
-                  timeframe_ms="${timeframe_ms}"/>
+                  timeframe_ms="${timeframe_ms}" 
+                  use_fake_hardware="$(arg use_fake_hardware)"/>
 </robot>

--- a/kuka_lbr_iisy_support/urdf/lbr_iisy3_r760_macro.xacro
+++ b/kuka_lbr_iisy_support/urdf/lbr_iisy3_r760_macro.xacro
@@ -5,7 +5,7 @@
   <xacro:include filename="$(find kuka_resources)/urdf/common_materials.xacro"/>
   <xacro:include filename="$(find kuka_lbr_iisy_support)/urdf/lbr_iisy_transmission.xacro" />
   
-  <xacro:macro name="kuka_lbr3_r760_robot" params="prefix client_ip controller_ip control_mode consequent_lost_packets lost_packets_in_timeframe timeframe_ms">
+  <xacro:macro name="kuka_lbr3_r760_robot" params="prefix client_ip controller_ip control_mode consequent_lost_packets lost_packets_in_timeframe timeframe_ms use_fake_hardware:=false">
     <!-- ros2 control instance -->
     <xacro:kuka_lbr_iisy_ros2_control
     name="LBRiisy3R760" 
@@ -15,7 +15,8 @@
     control_mode="${control_mode}"
     consequent_lost_packets="${consequent_lost_packets}"
     lost_packets_in_timeframe="${lost_packets_in_timeframe}"
-    timeframe_ms="${timeframe_ms}" />
+    timeframe_ms="${timeframe_ms}" 
+    use_fake_hardware="${use_fake_hardware}" />
 
     <!-- links - main serial chain -->
     <!-- links - root element cannot have inertia, therefore a dummy base_link is needed -->

--- a/kuka_lbr_iisy_support/urdf/lbr_iisy_ros2_control.xacro
+++ b/kuka_lbr_iisy_support/urdf/lbr_iisy_ros2_control.xacro
@@ -1,15 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="kuka_lbr_iisy_ros2_control" params="name prefix client_ip controller_ip control_mode consequent_lost_packets lost_packets_in_timeframe timeframe_ms">
+  <xacro:macro name="kuka_lbr_iisy_ros2_control" params="name prefix client_ip controller_ip control_mode consequent_lost_packets lost_packets_in_timeframe timeframe_ms use_fake_hardware:=false">
     <ros2_control name="${name}" type="system">
       <hardware>
-        <plugin>kuka_rox::KukaRoXHardwareInterface</plugin>
-        <param name="client_ip">${client_ip}</param>
-        <param name="controller_ip">${controller_ip}</param>
-        <param name="control_mode">${control_mode}</param>
-        <param name="consequent_lost_packets">${consequent_lost_packets}</param>
-        <param name="lost_packets_in_timeframe">${lost_packets_in_timeframe}</param>
-        <param name="timeframe_ms">${timeframe_ms}</param>
+        <xacro:if value="${use_fake_hardware}">
+          <plugin>mock_components/GenericSystem</plugin>
+          <param name="fake_sensor_commands">false</param>
+          <param name="state_following_offset">0.0</param>
+        </xacro:if>
+        <xacro:unless value="${use_fake_hardware}">
+          <plugin>kuka_rox::KukaRoXHardwareInterface</plugin>
+          <param name="client_ip">${client_ip}</param>
+          <param name="controller_ip">${controller_ip}</param>
+          <param name="control_mode">${control_mode}</param>
+          <param name="consequent_lost_packets">${consequent_lost_packets}</param>
+          <param name="lost_packets_in_timeframe">${lost_packets_in_timeframe}</param>
+          <param name="timeframe_ms">${timeframe_ms}</param>
+        </xacro:unless>
       </hardware>
       <!-- define joints and command/state interfaces for each joint -->
       <joint name="${prefix}joint_a1">


### PR DESCRIPTION
I'm working on standing up a MoveIt Studio configuration for the LBR iisy 3 R760, and part of that involves using ros2_control's mock components to get a simple simulation going:

![image](https://github.com/kroshu/kuka_simulators/assets/4603398/d376a2de-e1a9-493d-beba-2678eb284808)

In doing so, I made a few changes by adding a new argument to the xacro.