### PR TITLE
Add KR 560 R3100-2 OPW parameters

### DIFF
--- a/kuka_fortec_support/config/opw_parameters_kr560_r3100_2.yaml
+++ b/kuka_fortec_support/config/opw_parameters_kr560_r3100_2.yaml
@@ -1,0 +1,20 @@
+#
+# Parameters for use with IK solvers which support OPW (Ortho-Parallel Wrist)
+# kinematic configurations, as described in the paper "An Analytical Solution
+# of the Inverse Kinematics Problem of Industrial Serial Manipulators with an
+# Ortho-parallel Basis and a Spherical Wrist" by Mathias Brandstötter, Arthur
+# Angerer, and Michael Hofbaur (Proceedings of the Austrian Robotics Workshop
+# 2014, 22-23 May, 2014, Linz, Austria).
+#
+# The moveit_opw_kinematics_plugin package provides such a solver.
+#
+opw_kinematics_geometric_parameters:
+    a1:  0.500
+    a2:  -0.180
+    b:   0.000
+    c1:  0.860
+    c2:  1.550
+    c3:  1.0345
+    c4:  0.305
+opw_kinematics_joint_offsets: [0.0, deg(-90.0), 0.0, 0.0, 0.0, 0.0]
+opw_kinematics_joint_sign_corrections: [-1, 1, 1, -1, 1, -1]


### PR DESCRIPTION
### Before submitting this PR into master please make sure:

~~If you added a new robot model:~~
~~If you modified an already existing robot model:~~

Note: none of the tables in the `README` reference the presence of OPW parameters, thus I have not updated the `README`.

### Short description of the change

Added the OPW parameters for the KR 560 R3100-2 robot in the same format as existing opw parameters files in this repo. Note that the parameters were determined manually from the urdf of the robot (and verified against [a diagram](https://robotec.org/upload/iblock/b06/u1pbu02357xin5ip5iedqeqikyecex49.jpg) of the KR560). I was able to verify the parameters with [tesseract](https://github.com/tesseract-robotics/tesseract) using two poses (and then performing FK), however I have no programatic way to check the file I added here (tesseract expects a slightly different format when loading the parameters).

I would highly recommend double checking the OPW parameters before merging (in case I made a mistake or the tesseract solver uses a slightly different convention from the standardised files).

This would fix #111 