### PR TITLE
Cmake find package fix

### DIFF
--- a/kuka_gazebo/CMakeLists.txt
+++ b/kuka_gazebo/CMakeLists.txt
@@ -12,9 +12,6 @@ find_package(moveit_ros_planning_interface REQUIRED)
 find_package(moveit_visual_tools REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
-find_package(ros2_control REQUIRED)
-find_package(ros2_controllers REQUIRED)
-find_package(controller_manager REQUIRED)
 
 include_directories(include)
 


### PR DESCRIPTION
### Before submitting this PR into master please make sure:
If you added a new robot model:
- [ ] you extended the table of verified data in `README.md` with the new model
- [ ] you extended the CMakeLists.txt of the appropriate moveit configuration package with the new model
- [ ] you added a `test_<robot_model>.launch.py` and after launching the robot was visible in `rviz`
- [ ] you started a `gazebo` simulation with the new robot without any errors
- [ ] you added a `<robot_model>_joint_limits.yaml` file in the `config` directory (to provide moveit support)

If you modified an already existing robot model:
- [ ] you checked and optionally updated the table of verified data in `README.md` with the changes
- [ ] you have run the `test_<robot_model>.launch.py` and the robot was visible in `rviz`

### Short description of the change
