### PR TITLE
Add commanded_position state interfaces to joint impedance controlled robots

### DIFF
--- a/kuka_lbr_iisy_support/urdf/lbr_iisy_ros2_control_macro.xacro
+++ b/kuka_lbr_iisy_support/urdf/lbr_iisy_ros2_control_macro.xacro
@@ -95,7 +95,7 @@
           </state_interface>
           <state_interface name="commanded_position">
             <param name="initial_value">0.0</param>
-          </state_interface>          
+          </state_interface>
         </xacro:if>
       </joint>
       <joint name="${prefix}joint_3">

--- a/kuka_lbr_iiwa_support/urdf/lbr_iiwa_ros2_control_macro.xacro
+++ b/kuka_lbr_iiwa_support/urdf/lbr_iiwa_ros2_control_macro.xacro
@@ -46,8 +46,8 @@
           <param name="initial_value">0.0</param>
         </state_interface>
         <state_interface name="commanded_position">
-            <param name="initial_value">0.0</param>
-        </state_interface> 
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <joint name="${prefix}joint_2">
         <command_interface name="position"/>
@@ -67,7 +67,7 @@
         </state_interface>
         <state_interface name="commanded_position">
           <param name="initial_value">0.0</param>
-        </state_interface> 
+        </state_interface>
       </joint>
       <joint name="${prefix}joint_3">
         <command_interface name="position"/>
@@ -87,7 +87,7 @@
         </state_interface>
         <state_interface name="commanded_position">
           <param name="initial_value">0.0</param>
-        </state_interface> 
+        </state_interface>
       </joint>
       <joint name="${prefix}joint_4">
         <command_interface name="position"/>
@@ -107,7 +107,7 @@
         </state_interface>
         <state_interface name="commanded_position">
           <param name="initial_value">0.0</param>
-        </state_interface> 
+        </state_interface>
       </joint>
       <joint name="${prefix}joint_5">
         <command_interface name="position"/>
@@ -127,7 +127,7 @@
         </state_interface>
         <state_interface name="commanded_position">
           <param name="initial_value">0.0</param>
-        </state_interface> 
+        </state_interface>
       </joint>
       <joint name="${prefix}joint_6">
         <command_interface name="position"/>
@@ -147,7 +147,7 @@
         </state_interface>
         <state_interface name="commanded_position">
           <param name="initial_value">0.0</param>
-        </state_interface> 
+        </state_interface>
       </joint>
       <joint name="${prefix}joint_7">
         <command_interface name="position"/>
@@ -167,7 +167,7 @@
         </state_interface>
         <state_interface name="commanded_position">
           <param name="initial_value">0.0</param>
-        </state_interface> 
+        </state_interface>
       </joint>
       <xacro:if value="${mode == 'hardware'}">
         <xacro:if value="${io_access}">


### PR DESCRIPTION
### Before submitting this PR into master please make sure:
If you added a new robot model:
- [ ] you extended the table of verified data in `README.md` with the new model
- [ ] you extended the CMakeLists.txt of the appropriate moveit configuration package with the new model
- [ ] you added a `test_<robot_model>.launch.py` and after launching the robot was visible in `rviz`
- [ ] you started a `gazebo` simulation with the new robot without any errors
- [ ] you added a `<robot_model>_joint_limits.yaml` file in the `config` directory (to provide moveit support)

If you modified an already existing robot model:
- [ ] you checked and optionally updated the table of verified data in `README.md` with the changes
- [ ] you have run the `test_<robot_model>.launch.py` and the robot was visible in `rviz`

### Short description of the change
