### PR TITLE
Add velocity and effort interfaces to robot joints

### DIFF
--- a/kuka_agilus_support/urdf/kr_agilus_ros2_control_macro.xacro
+++ b/kuka_agilus_support/urdf/kr_agilus_ros2_control_macro.xacro
@@ -49,63 +49,99 @@
       <xacro:insert_block name="ext_axes_ros2_control_joints"/>
       <joint name="${prefix}joint_1">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_2">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">-1.5708</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_3">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">1.5708</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_4">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_5">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_6">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <xacro:if value="${use_gpio}">
         <xacro:include filename="$(find kuka_rsi_driver)/config/gpio_config.xacro"/>

--- a/kuka_agilus_support/urdf/kr_agilus_ros2_control_macro.xacro
+++ b/kuka_agilus_support/urdf/kr_agilus_ros2_control_macro.xacro
@@ -49,39 +49,63 @@
       <xacro:insert_block name="ext_axes_ros2_control_joints"/>
       <joint name="${prefix}joint_1">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint_2">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">-1.5708</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint_3">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">1.5708</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint_4">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint_5">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint_6">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <xacro:if value="${use_gpio}">
         <xacro:include filename="$(find kuka_rsi_driver)/config/gpio_config.xacro"/>

--- a/kuka_cybertech_support/urdf/kr_cybertech_ros2_control_macro.xacro
+++ b/kuka_cybertech_support/urdf/kr_cybertech_ros2_control_macro.xacro
@@ -49,63 +49,99 @@
       <xacro:insert_block name="ext_axes_ros2_control_joints"/>
       <joint name="${prefix}joint_1">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_2">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">-1.5708</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_3">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">1.5708</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_4">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_5">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_6">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <xacro:if value="${use_gpio}">
         <xacro:include filename="$(find kuka_rsi_driver)/config/gpio_config.xacro"/>

--- a/kuka_cybertech_support/urdf/kr_cybertech_ros2_control_macro.xacro
+++ b/kuka_cybertech_support/urdf/kr_cybertech_ros2_control_macro.xacro
@@ -49,39 +49,63 @@
       <xacro:insert_block name="ext_axes_ros2_control_joints"/>
       <joint name="${prefix}joint_1">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint_2">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">-1.5708</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint_3">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">1.5708</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint_4">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint_5">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint_6">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <xacro:if value="${use_gpio}">
         <xacro:include filename="$(find kuka_rsi_driver)/config/gpio_config.xacro"/>

--- a/kuka_fortec_support/urdf/kr_fortec_ros2_control_macro.xacro
+++ b/kuka_fortec_support/urdf/kr_fortec_ros2_control_macro.xacro
@@ -49,63 +49,99 @@
       <xacro:insert_block name="ext_axes_ros2_control_joints"/>
       <joint name="${prefix}joint_1">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_2">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">-1.5708</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_3">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">1.5708</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_4">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_5">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_6">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <xacro:if value="${use_gpio}">
         <xacro:include filename="$(find kuka_rsi_driver)/config/gpio_config.xacro"/>

--- a/kuka_fortec_support/urdf/kr_fortec_ros2_control_macro.xacro
+++ b/kuka_fortec_support/urdf/kr_fortec_ros2_control_macro.xacro
@@ -49,39 +49,63 @@
       <xacro:insert_block name="ext_axes_ros2_control_joints"/>
       <joint name="${prefix}joint_1">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint_2">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">-1.5708</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint_3">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">1.5708</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint_4">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint_5">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint_6">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <xacro:if value="${use_gpio}">
         <xacro:include filename="$(find kuka_rsi_driver)/config/gpio_config.xacro"/>

--- a/kuka_iontec_support/urdf/kr_iontec_ros2_control_macro.xacro
+++ b/kuka_iontec_support/urdf/kr_iontec_ros2_control_macro.xacro
@@ -49,63 +49,99 @@
       <xacro:insert_block name="ext_axes_ros2_control_joints"/>
       <joint name="${prefix}joint_1">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_2">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">-1.5708</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_3">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">1.5708</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_4">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_5">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_6">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <xacro:if value="${use_gpio}">
         <xacro:include filename="$(find kuka_rsi_driver)/config/gpio_config.xacro"/>

--- a/kuka_iontec_support/urdf/kr_iontec_ros2_control_macro.xacro
+++ b/kuka_iontec_support/urdf/kr_iontec_ros2_control_macro.xacro
@@ -49,39 +49,63 @@
       <xacro:insert_block name="ext_axes_ros2_control_joints"/>
       <joint name="${prefix}joint_1">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint_2">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">-1.5708</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint_3">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">1.5708</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint_4">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint_5">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint_6">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <xacro:if value="${use_gpio}">
         <xacro:include filename="$(find kuka_rsi_driver)/config/gpio_config.xacro"/>

--- a/kuka_kl_support/urdf/kl_ros2_control_macro.xacro
+++ b/kuka_kl_support/urdf/kl_ros2_control_macro.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="kuka_kl_ros2_control_joints" params="mode:='hardware'">
+  <xacro:macro name="kuka_kl_ros2_control_joints" params="">
     <joint name="rail_joint">
       <param name="type">prismatic</param>
       <param name="is_external">true</param>

--- a/kuka_kl_support/urdf/kl_ros2_control_macro.xacro
+++ b/kuka_kl_support/urdf/kl_ros2_control_macro.xacro
@@ -5,9 +5,13 @@
       <param name="type">prismatic</param>
       <param name="is_external">true</param>
       <command_interface name="position"/>
+      <command_interface name="velocity"/>
+      <command_interface name="effort"/>
       <state_interface name="position">
         <param name="initial_value">0.0</param>
       </state_interface>
+      <state_interface name="velocity"/>
+      <state_interface name="effort"/>
     </joint>
   </xacro:macro>
 </robot>

--- a/kuka_kl_support/urdf/kl_ros2_control_macro.xacro
+++ b/kuka_kl_support/urdf/kl_ros2_control_macro.xacro
@@ -1,17 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="kuka_kl_ros2_control_joints" params="">
+  <xacro:macro name="kuka_kl_ros2_control_joints" params="mode:='hardware'">
     <joint name="rail_joint">
       <param name="type">prismatic</param>
       <param name="is_external">true</param>
       <command_interface name="position"/>
-      <command_interface name="velocity"/>
-      <command_interface name="effort"/>
       <state_interface name="position">
         <param name="initial_value">0.0</param>
       </state_interface>
-      <state_interface name="velocity"/>
-      <state_interface name="effort"/>
+      <xacro:unless value="${mode == 'gazebo'}">
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+      </xacro:unless>
     </joint>
   </xacro:macro>
 </robot>

--- a/kuka_lbr_iisy_support/urdf/lbr_iisy_ros2_control_macro.xacro
+++ b/kuka_lbr_iisy_support/urdf/lbr_iisy_ros2_control_macro.xacro
@@ -69,6 +69,10 @@
       <!-- define joints and command/state interfaces for each joint -->
       <joint name="${prefix}joint_1">
         <command_interface name="position"/>
+        <xacro:unless value="${driver_version == 'eac'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+        </xacro:unless>
         <xacro:if value="${driver_version == 'eac' and mode != 'gazebo'}">
           <command_interface name="stiffness"/>
           <command_interface name="damping"/>
@@ -77,6 +81,10 @@
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
+        <xacro:unless value="${driver_version == 'eac'}">
+          <state_interface name="velocity"/>
+          <state_interface name="effort"/>
+        </xacro:unless>
         <xacro:if value="${driver_version == 'eac'}">
           <state_interface name="effort">
             <param name="initial_value">0.0</param>
@@ -88,6 +96,10 @@
       </joint>
       <joint name="${prefix}joint_2">
         <command_interface name="position"/>
+        <xacro:unless value="${driver_version == 'eac'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+        </xacro:unless>
         <xacro:if value="${driver_version == 'eac' and mode != 'gazebo'}">
           <command_interface name="stiffness"/>
           <command_interface name="damping"/>
@@ -96,6 +108,10 @@
         <state_interface name="position">
           <param name="initial_value">-1.5708</param>
         </state_interface>
+        <xacro:unless value="${driver_version == 'eac'}">
+          <state_interface name="velocity"/>
+          <state_interface name="effort"/>
+        </xacro:unless>
         <xacro:if value="${driver_version == 'eac'}">
           <state_interface name="effort">
             <param name="initial_value">0.0</param>
@@ -107,6 +123,10 @@
       </joint>
       <joint name="${prefix}joint_3">
         <command_interface name="position"/>
+        <xacro:unless value="${driver_version == 'eac'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+        </xacro:unless>
         <xacro:if value="${driver_version == 'eac' and mode != 'gazebo'}">
           <command_interface name="stiffness"/>
           <command_interface name="damping"/>
@@ -115,6 +135,10 @@
         <state_interface name="position">
           <param name="initial_value">1.5708</param>
         </state_interface>
+        <xacro:unless value="${driver_version == 'eac'}">
+          <state_interface name="velocity"/>
+          <state_interface name="effort"/>
+        </xacro:unless>
         <xacro:if value="${driver_version == 'eac'}">
           <state_interface name="effort">
             <param name="initial_value">0.0</param>
@@ -126,6 +150,10 @@
       </joint>
       <joint name="${prefix}joint_4">
         <command_interface name="position"/>
+        <xacro:unless value="${driver_version == 'eac'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+        </xacro:unless>
         <xacro:if value="${driver_version == 'eac' and mode != 'gazebo'}">
           <command_interface name="stiffness"/>
           <command_interface name="damping"/>
@@ -134,6 +162,10 @@
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
+        <xacro:unless value="${driver_version == 'eac'}">
+          <state_interface name="velocity"/>
+          <state_interface name="effort"/>
+        </xacro:unless>
         <xacro:if value="${driver_version == 'eac'}">
           <state_interface name="effort">
             <param name="initial_value">0.0</param>
@@ -145,6 +177,10 @@
       </joint>
       <joint name="${prefix}joint_5">
         <command_interface name="position"/>
+        <xacro:unless value="${driver_version == 'eac'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+        </xacro:unless>
         <xacro:if value="${driver_version == 'eac' and mode != 'gazebo'}">
           <command_interface name="stiffness"/>
           <command_interface name="damping"/>
@@ -153,6 +189,10 @@
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
+        <xacro:unless value="${driver_version == 'eac'}">
+          <state_interface name="velocity"/>
+          <state_interface name="effort"/>
+        </xacro:unless>
         <xacro:if value="${driver_version == 'eac'}">
           <state_interface name="effort">
             <param name="initial_value">0.0</param>
@@ -164,6 +204,10 @@
       </joint>
       <joint name="${prefix}joint_6">
         <command_interface name="position"/>
+        <xacro:unless value="${driver_version == 'eac'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+        </xacro:unless>
         <xacro:if value="${driver_version == 'eac' and mode != 'gazebo'}">
           <command_interface name="stiffness"/>
           <command_interface name="damping"/>
@@ -172,6 +216,10 @@
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
+        <xacro:unless value="${driver_version == 'eac'}">
+          <state_interface name="velocity"/>
+          <state_interface name="effort"/>
+        </xacro:unless>
         <xacro:if value="${driver_version == 'eac'}">
           <state_interface name="effort">
             <param name="initial_value">0.0</param>

--- a/kuka_lbr_iisy_support/urdf/lbr_iisy_ros2_control_macro.xacro
+++ b/kuka_lbr_iisy_support/urdf/lbr_iisy_ros2_control_macro.xacro
@@ -69,165 +69,153 @@
       <!-- define joints and command/state interfaces for each joint -->
       <joint name="${prefix}joint_1">
         <command_interface name="position"/>
-        <xacro:unless value="${driver_version == 'eac'}">
-          <command_interface name="velocity"/>
-          <command_interface name="effort"/>
-        </xacro:unless>
-        <xacro:if value="${driver_version == 'eac' and mode != 'gazebo'}">
-          <command_interface name="stiffness"/>
-          <command_interface name="damping"/>
-          <command_interface name="effort"/>
-        </xacro:if>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <xacro:unless value="${driver_version == 'eac'}">
-          <state_interface name="velocity"/>
-          <state_interface name="effort"/>
-        </xacro:unless>
-        <xacro:if value="${driver_version == 'eac'}">
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="effort"/>
           <state_interface name="effort">
             <param name="initial_value">0.0</param>
           </state_interface>
-          <state_interface name="commanded_position">
-            <param name="initial_value">0.0</param>
-          </state_interface>
-        </xacro:if>
+          <xacro:if value="${driver_version == 'eac'}">
+            <command_interface name="stiffness"/>
+            <command_interface name="damping"/>
+            <state_interface name="commanded_position">
+              <param name="initial_value">0.0</param>
+            </state_interface>
+          </xacro:if>
+          <xacro:unless value="${driver_version == 'eac'}">
+            <command_interface name="velocity"/>
+            <state_interface name="velocity">
+              <param name="initial_value">0.0</param>
+            </state_interface>
+          </xacro:unless>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_2">
         <command_interface name="position"/>
-        <xacro:unless value="${driver_version == 'eac'}">
-          <command_interface name="velocity"/>
-          <command_interface name="effort"/>
-        </xacro:unless>
-        <xacro:if value="${driver_version == 'eac' and mode != 'gazebo'}">
-          <command_interface name="stiffness"/>
-          <command_interface name="damping"/>
-          <command_interface name="effort"/>
-        </xacro:if>
         <state_interface name="position">
           <param name="initial_value">-1.5708</param>
         </state_interface>
-        <xacro:unless value="${driver_version == 'eac'}">
-          <state_interface name="velocity"/>
-          <state_interface name="effort"/>
-        </xacro:unless>
-        <xacro:if value="${driver_version == 'eac'}">
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="effort"/>
           <state_interface name="effort">
             <param name="initial_value">0.0</param>
           </state_interface>
-          <state_interface name="commanded_position">
-            <param name="initial_value">0.0</param>
-          </state_interface>
-        </xacro:if>
+          <xacro:if value="${driver_version == 'eac'}">
+            <command_interface name="stiffness"/>
+            <command_interface name="damping"/>
+            <state_interface name="commanded_position">
+              <param name="initial_value">0.0</param>
+            </state_interface>
+          </xacro:if>
+          <xacro:unless value="${driver_version == 'eac'}">
+            <command_interface name="velocity"/>
+            <state_interface name="velocity">
+              <param name="initial_value">0.0</param>
+            </state_interface>
+          </xacro:unless>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_3">
         <command_interface name="position"/>
-        <xacro:unless value="${driver_version == 'eac'}">
-          <command_interface name="velocity"/>
-          <command_interface name="effort"/>
-        </xacro:unless>
-        <xacro:if value="${driver_version == 'eac' and mode != 'gazebo'}">
-          <command_interface name="stiffness"/>
-          <command_interface name="damping"/>
-          <command_interface name="effort"/>
-        </xacro:if>
         <state_interface name="position">
           <param name="initial_value">1.5708</param>
         </state_interface>
-        <xacro:unless value="${driver_version == 'eac'}">
-          <state_interface name="velocity"/>
-          <state_interface name="effort"/>
-        </xacro:unless>
-        <xacro:if value="${driver_version == 'eac'}">
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="effort"/>
           <state_interface name="effort">
             <param name="initial_value">0.0</param>
           </state_interface>
-          <state_interface name="commanded_position">
-            <param name="initial_value">0.0</param>
-          </state_interface>
-        </xacro:if>
+          <xacro:if value="${driver_version == 'eac'}">
+            <command_interface name="stiffness"/>
+            <command_interface name="damping"/>
+            <state_interface name="commanded_position">
+              <param name="initial_value">0.0</param>
+            </state_interface>
+          </xacro:if>
+          <xacro:unless value="${driver_version == 'eac'}">
+            <command_interface name="velocity"/>
+            <state_interface name="velocity">
+              <param name="initial_value">0.0</param>
+            </state_interface>
+          </xacro:unless>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_4">
         <command_interface name="position"/>
-        <xacro:unless value="${driver_version == 'eac'}">
-          <command_interface name="velocity"/>
-          <command_interface name="effort"/>
-        </xacro:unless>
-        <xacro:if value="${driver_version == 'eac' and mode != 'gazebo'}">
-          <command_interface name="stiffness"/>
-          <command_interface name="damping"/>
-          <command_interface name="effort"/>
-        </xacro:if>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <xacro:unless value="${driver_version == 'eac'}">
-          <state_interface name="velocity"/>
-          <state_interface name="effort"/>
-        </xacro:unless>
-        <xacro:if value="${driver_version == 'eac'}">
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="effort"/>
           <state_interface name="effort">
             <param name="initial_value">0.0</param>
           </state_interface>
-          <state_interface name="commanded_position">
-            <param name="initial_value">0.0</param>
-          </state_interface>
-        </xacro:if>
+          <xacro:if value="${driver_version == 'eac'}">
+            <command_interface name="stiffness"/>
+            <command_interface name="damping"/>
+            <state_interface name="commanded_position">
+              <param name="initial_value">0.0</param>
+            </state_interface>
+          </xacro:if>
+          <xacro:unless value="${driver_version == 'eac'}">
+            <command_interface name="velocity"/>
+            <state_interface name="velocity">
+              <param name="initial_value">0.0</param>
+            </state_interface>
+          </xacro:unless>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_5">
         <command_interface name="position"/>
-        <xacro:unless value="${driver_version == 'eac'}">
-          <command_interface name="velocity"/>
-          <command_interface name="effort"/>
-        </xacro:unless>
-        <xacro:if value="${driver_version == 'eac' and mode != 'gazebo'}">
-          <command_interface name="stiffness"/>
-          <command_interface name="damping"/>
-          <command_interface name="effort"/>
-        </xacro:if>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <xacro:unless value="${driver_version == 'eac'}">
-          <state_interface name="velocity"/>
-          <state_interface name="effort"/>
-        </xacro:unless>
-        <xacro:if value="${driver_version == 'eac'}">
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="effort"/>
           <state_interface name="effort">
             <param name="initial_value">0.0</param>
           </state_interface>
-          <state_interface name="commanded_position">
-            <param name="initial_value">0.0</param>
-          </state_interface>
-        </xacro:if>
+          <xacro:if value="${driver_version == 'eac'}">
+            <command_interface name="stiffness"/>
+            <command_interface name="damping"/>
+            <state_interface name="commanded_position">
+              <param name="initial_value">0.0</param>
+            </state_interface>
+          </xacro:if>
+          <xacro:unless value="${driver_version == 'eac'}">
+            <command_interface name="velocity"/>
+            <state_interface name="velocity">
+              <param name="initial_value">0.0</param>
+            </state_interface>
+          </xacro:unless>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_6">
         <command_interface name="position"/>
-        <xacro:unless value="${driver_version == 'eac'}">
-          <command_interface name="velocity"/>
-          <command_interface name="effort"/>
-        </xacro:unless>
-        <xacro:if value="${driver_version == 'eac' and mode != 'gazebo'}">
-          <command_interface name="stiffness"/>
-          <command_interface name="damping"/>
-          <command_interface name="effort"/>
-        </xacro:if>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <xacro:unless value="${driver_version == 'eac'}">
-          <state_interface name="velocity"/>
-          <state_interface name="effort"/>
-        </xacro:unless>
-        <xacro:if value="${driver_version == 'eac'}">
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="effort"/>
           <state_interface name="effort">
             <param name="initial_value">0.0</param>
           </state_interface>
-          <state_interface name="commanded_position">
-            <param name="initial_value">0.0</param>
-          </state_interface>
-        </xacro:if>
+          <xacro:if value="${driver_version == 'eac'}">
+            <command_interface name="stiffness"/>
+            <command_interface name="damping"/>
+            <state_interface name="commanded_position">
+              <param name="initial_value">0.0</param>
+            </state_interface>
+          </xacro:if>
+          <xacro:unless value="${driver_version == 'eac'}">
+            <command_interface name="velocity"/>
+            <state_interface name="velocity">
+              <param name="initial_value">0.0</param>
+            </state_interface>
+          </xacro:unless>
+        </xacro:unless>
       </joint>
       <xacro:if value="${use_gpio}">
         <xacro:include filename="$(find kuka_rsi_driver)/config/gpio_config.xacro"/>

--- a/kuka_quantec_support/urdf/kr_quantec_ros2_control_macro.xacro
+++ b/kuka_quantec_support/urdf/kr_quantec_ros2_control_macro.xacro
@@ -49,63 +49,99 @@
       <xacro:insert_block name="ext_axes_ros2_control_joints"/>
       <joint name="${prefix}joint_1">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_2">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">-1.5708</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_3">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">1.5708</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_4">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_5">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <joint name="${prefix}joint_6">
         <command_interface name="position"/>
-        <command_interface name="velocity"/>
-        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="velocity"/>
+          <command_interface name="effort"/>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="effort">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+        </xacro:unless>
       </joint>
       <xacro:if value="${use_gpio}">
         <xacro:include filename="$(find kuka_rsi_driver)/config/gpio_config.xacro"/>

--- a/kuka_quantec_support/urdf/kr_quantec_ros2_control_macro.xacro
+++ b/kuka_quantec_support/urdf/kr_quantec_ros2_control_macro.xacro
@@ -49,39 +49,63 @@
       <xacro:insert_block name="ext_axes_ros2_control_joints"/>
       <joint name="${prefix}joint_1">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint_2">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">-1.5708</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint_3">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">1.5708</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint_4">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint_5">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint_6">
         <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </joint>
       <xacro:if value="${use_gpio}">
         <xacro:include filename="$(find kuka_rsi_driver)/config/gpio_config.xacro"/>


### PR DESCRIPTION
### Short description of the change

RSI compatible robots are extended with torque and velocity interfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded supported robot joint control interfaces to include **position**, **velocity**, and **effort** commands, along with matching **velocity** and **effort** feedback interfaces.
  * Kept existing **position** feedback behavior and per-joint initial-value handling unchanged.
  * Applied the enhancements across Agilus, Cybertech, Fortec, Iontec, LBR iiwa, Quantec, and rail axes.
  * In **gazebo** mode, additional velocity/effort interfaces are omitted; EAC-specific interfaces remain available for the LBR iiwa configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->