### PR TITLE
Fix mock hardware `on_init`

### DIFF
--- a/kuka_mock_hardware_interface/src/hardware_interface.cpp
+++ b/kuka_mock_hardware_interface/src/hardware_interface.cpp
@@ -24,7 +24,8 @@ namespace kuka_mock_hardware_interface
 {
 CallbackReturn KukaMockHardwareInterface::on_init(const hardware_interface::HardwareInfo & info)
 {
-  auto ret = hardware_interface::SystemInterface::on_init(info);
+  // Initialize GenericSystem internals before using its export/read/write implementation.
+  auto ret = mock_components::GenericSystem::on_init(info);
   if (ret != CallbackReturn::SUCCESS)
   {
     return ret;


### PR DESCRIPTION
### Before submitting this PR into master please make sure:
If you added a new robot model:
- [ ] you extended the table of verified data in `README.md` with the new model
- [ ] you extended the CMakeLists.txt of the appropriate moveit configuration package with the new model
- [ ] you added a `test_<robot_model>.launch.py` and after launching the robot was visible in `rviz`
- [ ] you started a `gazebo` simulation with the new robot without any errors
- [ ] you added a `<robot_model>_joint_limits.yaml` file in the `config` directory (to provide moveit support)

If you modified an already existing robot model:
- [ ] you checked and optionally updated the table of verified data in `README.md` with the changes
- [ ] you have run the `test_<robot_model>.launch.py` and the robot was visible in `rviz`

### Short description of the change
