### PR TITLE
Fix missing mode parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ With an external axis (KL100-2 in this example):
 <xacro:kuka_robotfamily_ros2_control ...>
   <ext_axes_ros2_control_joints>
     <!-- kl ros2 control joints -->
-    <xacro:kuka_kl_ros2_control_joints/>
+    <xacro:kuka_kl_ros2_control_joints mode="..."/>
   </ext_axes_ros2_control_joints>
 </xacro:kuka_robotfamily_ros2_control>
 

--- a/kuka_kl_support/urdf/kl_ros2_control_macro.xacro
+++ b/kuka_kl_support/urdf/kl_ros2_control_macro.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="kuka_kl_ros2_control_joints" params="">
+  <xacro:macro name="kuka_kl_ros2_control_joints" params="mode">
     <joint name="rail_joint">
       <param name="type">prismatic</param>
       <param name="is_external">true</param>


### PR DESCRIPTION
### Short description of the change

A missing parameter has been added to one of the Xacro files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed control configuration handling for simulation mode.
  - Velocity and effort interfaces are now correctly included or omitted based on the selected control mode.
- **Documentation**
  - Updated the README “External axis support” URDF/Xacro example to include the required `mode` argument in the macro call.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->